### PR TITLE
Fix bug with new CMake version

### DIFF
--- a/src/types_MPI.h
+++ b/src/types_MPI.h
@@ -14,6 +14,6 @@
 }
 
 typedef CUSTOM_MPI_DATATYPE(60) t_non_datatype;
-const t_non_datatype T_NON_TYPE;
+extern const t_non_datatype T_NON_TYPE;
 
 #endif


### PR DESCRIPTION
Fixes #16 

Multiple definition is solved by declaring T_NON_TYPE in types_MPI.h using "extern",
rather than defining it a second time.